### PR TITLE
fix(server): make Stop() complete when the accept loop is blocked

### DIFF
--- a/websocket-sharp/Net/WebSockets/TcpListenerWebSocketContext.cs
+++ b/websocket-sharp/Net/WebSockets/TcpListenerWebSocketContext.cs
@@ -80,6 +80,13 @@ namespace AltServerWebSocketSharp.Net.WebSockets
             _secure = secure;
             _log = log;
 
+            // Bound blocking sends so a peer that has gone unreachable (e.g. its network dropped
+            // mid-session) can't hang a send forever — this includes the server-initiated close
+            // handshake write, which previously could block indefinitely and wedge the server's
+            // shutdown/restart state. ReceiveTimeout is intentionally left unbounded: waiting for
+            // the next incoming message is normal and can legitimately take a long time.
+            tcpClient.Client.SendTimeout = 5000;
+
             var netStream = tcpClient.GetStream();
 
             if (secure)

--- a/websocket-sharp/Server/WebSocketServer.cs
+++ b/websocket-sharp/Server/WebSocketServer.cs
@@ -66,6 +66,8 @@ namespace AltServerWebSocketSharp.Server
         private bool _dnsStyle;
         private string _hostname;
         private TcpListener _listener;
+        // How long a single Accept poll waits before the loop re-checks for shutdown (microseconds).
+        private const int AcceptPollMicroseconds = 250000;
         private Logger _log;
         private int _port;
         private string _realm;
@@ -840,6 +842,17 @@ namespace AltServerWebSocketSharp.Server
 
                 try
                 {
+                    // Never park indefinitely in Accept. Disposing the listening socket while a
+                    // thread is blocked in AcceptTcpClient() makes TcpListener.Stop() hang forever
+                    // on Unix, which left the server stuck in ShuttingDown and made a later Start()
+                    // a silent no-op. Polling lets this loop notice a shutdown and exit by itself,
+                    // so stopReceiving() can join it before disposing the listener.
+                    if (_state == ServerState.ShuttingDown)
+                        return;
+
+                    if (!_listener.Server.Poll(AcceptPollMicroseconds, SelectMode.SelectRead))
+                        continue;
+
                     cl = _listener.AcceptTcpClient();
 
                     ThreadPool.QueueUserWorkItem(
@@ -1027,8 +1040,11 @@ namespace AltServerWebSocketSharp.Server
 
         private void stopReceiving(int millisecondsTimeout)
         {
-            _listener.Stop();
+            // Order matters: join first, dispose second. The accept loop polls and returns on its
+            // own once _state is ShuttingDown, so by the time we dispose the listener no thread is
+            // parked in Accept — which is what used to make Stop() hang forever on Unix.
             _receiveThread.Join(millisecondsTimeout);
+            _listener.Stop();
         }
 
         private static bool tryCreateUri(


### PR DESCRIPTION
TcpListener.Stop() blocks indefinitely on Unix when the accept thread is parked in a blocking AcceptTcpClient(). Because Stop() never returned, the server stayed in ShuttingDown forever and a later Start() silently no-opped (its guard returns early in that state), leaving the server permanently unable to accept connections.

- Poll the listening socket (250ms) before accepting, so the accept loop notices a shutdown and exits on its own instead of blocking in Accept.
- Join the receive thread before disposing the listener in stopReceiving(), so no thread is parked in Accept when the socket is closed.
- Set SendTimeout on accepted sockets so a write to a peer that has gone unreachable (including the server-initiated close handshake) cannot block forever.

This makes Stop()/Start() usable at runtime, which AltServer needs in order to stop serving while a subscription cannot be verified and resume once it can be verified again.