### PR TITLE
fix: dispatch the first queued message without BeginInvoke

### DIFF
--- a/websocket-sharp/WebSocket.cs
+++ b/websocket-sharp/WebSocket.cs
@@ -1795,7 +1795,14 @@ namespace AltServerWebSocketSharp
                 e = _messageEventQueue.Dequeue();
             }
 
-            _message.BeginInvoke(e, ar => _message.EndInvoke(ar), null);
+            // Reached when a frame arrived while the OnOpen handler above was still running: during
+            // OnOpen the receive loop only queues frames, because _inMessage is set. Dispatch the
+            // queued one on the thread pool rather than through Delegate.BeginInvoke, which is
+            // unsupported on .NET Core and throws PlatformNotSupportedException. That exception used
+            // to escape open() into the accept loop, which closed the TcpClient and so disposed the
+            // stream the receive loop was reading, dropping the connection on connect.
+            var queued = e;
+            ThreadPool.QueueUserWorkItem(_ => _message(queued));
         }
 
         private bool ping(byte[] data)


### PR DESCRIPTION
An app or Desktop that sent its first frame before the server returned from OnOpen was dropped as it connected (AltTester-Server issue #181):

  [Error] Operation is not supported on this platform.
  [Fatal] Cannot access a disposed object. Object name: 'System.Net.Sockets.NetworkStream'.
  ... disconnected.1006-An exception has occurred while receiving.

open() ended by handing the queued message to Delegate.BeginInvoke, which is unsupported on .NET Core and throws PlatformNotSupportedException. The exception escaped open() -> Accept() -> StartSession() into the accept loop, which logged it and closed the TcpClient; that disposed the stream the receive loop was already reading, so the loop died and aborted the session with 1006.

Queue the message on the thread pool instead. Only reached when a frame arrives while OnOpen is still running, which is why SDK 2.3.2+ and Desktop hit it (both speak immediately on connect) while older SDKs, silent until the server speaks first, never did.