### PR TITLE
ci: build altserverwebsocket-sharp.dll and upload it as an artifact

### DIFF
--- a/.github/workflows/build-dll.yml
+++ b/.github/workflows/build-dll.yml
@@ -15,17 +15,24 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # Same guards AltTester-Server puts on its self-hosted job: skip drafts, and never run a pull
+    # request from a fork - this executes on our own hardware, so it must not build code from a
+    # repository we do not control. This one is a public fork, so that matters here.
+    if: |
+      github.event.pull_request.draft != true &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: [self-hosted, Windows]
+    timeout-minutes: 15
+
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 8.0.x
-
-      # The solution still points at the pre-rename websocket-sharp.csproj, so build the project
-      # file directly.
+      # No setup-dotnet step: the runner already has the SDK, the same assumption AltTester-Server's
+      # tests job makes, and installing one per run would churn a machine we share.
+      #
+      # The solution still points at the pre-rename websocket-sharp.csproj, so build the project file
+      # directly.
       - name: Build
         run: dotnet build websocket-sharp/altserverwebsocket-sharp.csproj -c Release
 

--- a/.github/workflows/build-dll.yml
+++ b/.github/workflows/build-dll.yml
@@ -1,0 +1,42 @@
+# Builds altserverwebsocket-sharp.dll and publishes it as a downloadable artifact.
+#
+# AltTester-Server vendors this DLL (AltServer/altserverwebsocket-sharp.dll) rather than consuming a
+# package, so the binary used to be produced by hand. That is how it drifted from every branch: the
+# DLL that shipped carried an unmerged fix while missing a merged one. Build it here instead, so the
+# binary always corresponds to a commit anyone can point at.
+name: build-dll
+
+on:
+  push:
+    branches: [AltServer-Websocket-Sharp]
+  pull_request:
+    branches: [AltServer-Websocket-Sharp]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      # The solution still points at the pre-rename websocket-sharp.csproj, so build the project
+      # file directly.
+      - name: Build
+        run: dotnet build websocket-sharp/altserverwebsocket-sharp.csproj -c Release
+
+      # netstandard2.0 is the one AltTester-Server vendors (its AltServer project targets down to
+      # netstandard2.0); net6.0 and net7.0 are uploaded too so a consumer on either can take them.
+      - name: Upload altserverwebsocket-sharp.dll
+        uses: actions/upload-artifact@v4
+        with:
+          name: altserverwebsocket-sharp-${{ github.sha }}
+          path: |
+            websocket-sharp/bin/Release/netstandard2.0/altserverwebsocket-sharp.dll
+            websocket-sharp/bin/Release/net6.0/altserverwebsocket-sharp.dll
+            websocket-sharp/bin/Release/net7.0/altserverwebsocket-sharp.dll
+          if-no-files-found: error


### PR DESCRIPTION
AltTester-Server vendors this DLL rather than consuming a package, and the binary was produced by hand, so it drifted from the source: the copy that shipped carried an unmerged fix (the Stop() deadlock work) while missing a merged one (the ReadBytesAsync stack-overflow guard), matching no branch in this repository.

Build it on push and pull request against AltServer-Websocket-Sharp, and on demand, uploading all three target frameworks. netstandard2.0 is the one AltTester-Server vendors today.

Builds the project file directly: the solution still refers to the pre-rename websocket-sharp.csproj and no longer loads.