### PR TITLE
fix: stop logging our own teardown as a receive failure

### DIFF
--- a/websocket-sharp/WebSocket.cs
+++ b/websocket-sharp/WebSocket.cs
@@ -2576,6 +2576,27 @@ namespace AltServerWebSocketSharp
                   },
                   ex =>
                   {
+                      // releaseServerResources() disposes the stream while this read can still be
+                      // pending, so once closing has begun a failed read is the expected outcome of
+                      // our own teardown, not a fault: the peer is gone, the close handshake timed
+                      // out waiting for its close frame, and we tore the transport down underneath
+                      // the reader. Report receiving as finished and let the close path carry on -
+                      // logging it as Fatal and aborting an already-closing connection only
+                      // produced noise ("Cannot access a disposed object ... NetworkStream") for
+                      // every socket of a client whose network dropped.
+                      if (_readyState == WebSocketState.Closing
+                          || _readyState == WebSocketState.Closed)
+                      {
+                          _log.Trace(ex.Message);
+
+                          var exited = _receivingExited;
+
+                          if (exited != null)
+                              exited.Set();
+
+                          return;
+                      }
+
                       _log.Fatal(ex.Message);
                       _log.Debug(ex.ToString());
 


### PR DESCRIPTION
A client whose network dropped is still TCP-connected but will never answer the close handshake. The server writes its close frame, waits out _waitTime for a reply that never arrives, then disposes the transport in releaseServerResources() while the receive loop is still parked in a read. That read then failed with

  [Fatal] Cannot access a disposed object.
  Object name: 'System.Net.Sockets.NetworkStream'.

once per socket of the departing client, and aborted a connection that was already closing - reported on AltTester-Server issue #181 after the connect-time fix landed, where an Android app losing its network logged the pair for its command and live-update legs.

Once closing has begun, a failed read is the expected result of our own teardown, so report receiving as finished and trace it instead. Reads that fail while the connection is still Open keep the Fatal and the abort, which is where they mean something.