### PR TITLE
fix: stop closing the ping/receive wait handles while they are still …

### DIFF
--- a/websocket-sharp/Server/WebSocketSessionManager.cs
+++ b/websocket-sharp/Server/WebSocketSessionManager.cs
@@ -1622,38 +1622,43 @@ namespace AltServerWebSocketSharp.Server
                 _sweeping = true;
             }
 
-            foreach (var id in InactiveIDs)
+            try
             {
-                if (_state != ServerState.Start)
-                    break;
-
-                lock (_sync)
+                foreach (var id in InactiveIDs)
                 {
                     if (_state != ServerState.Start)
                         break;
 
-                    IWebSocketSession session;
-
-                    if (!_sessions.TryGetValue(id, out session))
-                        continue;
-
-                    var state = session.WebSocket.ReadyState;
-
-                    if (state == WebSocketState.Open)
+                    lock (_sync)
                     {
-                        session.WebSocket.Close(CloseStatusCode.Abnormal);
+                        if (_state != ServerState.Start)
+                            break;
 
-                        continue;
+                        IWebSocketSession session;
+
+                        if (!_sessions.TryGetValue(id, out session))
+                            continue;
+
+                        var state = session.WebSocket.ReadyState;
+
+                        if (state == WebSocketState.Open)
+                        {
+                            session.WebSocket.Close(CloseStatusCode.Abnormal);
+
+                            continue;
+                        }
+
+                        if (state == WebSocketState.Closing)
+                            continue;
+
+                        _sessions.Remove(id);
                     }
-
-                    if (state == WebSocketState.Closing)
-                        continue;
-
-                    _sessions.Remove(id);
                 }
             }
-
-            _sweeping = false;
+            finally
+            {
+                _sweeping = false;
+            }
         }
 
         /// <summary>

--- a/websocket-sharp/WebSocket.cs
+++ b/websocket-sharp/WebSocket.cs
@@ -1369,10 +1369,10 @@ namespace AltServerWebSocketSharp
                     frame.Unmask();
             }
 
-            var wait = !received && sent && _receivingExited != null;
+            var exited = _receivingExited;
 
-            if (wait)
-                received = _receivingExited.WaitOne(_waitTime);
+            if (!received && sent && exited != null)
+                received = exited.WaitOne(_waitTime);
 
             var ret = sent && received;
 
@@ -1946,7 +1946,12 @@ namespace AltServerWebSocketSharp
 
             try
             {
-                _pongReceived.Set();
+                var received = _pongReceived;
+
+                if (received == null)
+                    return false;
+
+                received.Set();
             }
             catch (NullReferenceException)
             {
@@ -2095,19 +2100,9 @@ namespace AltServerWebSocketSharp
                 _inContinuation = false;
             }
 
-            if (_pongReceived != null)
-            {
-                _pongReceived.Close();
 
-                _pongReceived = null;
-            }
-
-            if (_receivingExited != null)
-            {
-                _receivingExited.Close();
-
-                _receivingExited = null;
-            }
+            _pongReceived = null;
+            _receivingExited = null;
         }
 
         private void releaseResources()
@@ -2727,9 +2722,9 @@ namespace AltServerWebSocketSharp
             _log.Trace("Begin closing the connection.");
 
             var sent = rawFrame != null && sendBytes(rawFrame);
-            var received = sent && _receivingExited != null
-                           ? _receivingExited.WaitOne(_waitTime)
-                           : false;
+
+            var exited = _receivingExited;
+            var received = sent && exited != null && exited.WaitOne(_waitTime);
 
             var res = sent && received;
 


### PR DESCRIPTION
Fixes #13.

Fixes the crash reported in alttester/AltTester-Server#206.

`releaseCommonResources()` closed `_pongReceived` and `_receivingExited` out from under threads that were already inside `Reset`/`Set`/`WaitOne` on them — a use-after-dispose of an OS wait handle.

On the server, that window is opened by the session sweep: `Sweep()` → `InactiveIDs` → `broadping()` pings live connections, and a connection being torn down at that moment releases the handles underneath the ping. Both `AccessViolationException` reports in alttester/AltTester-Server#206 land on the first sweep tick, 60s after startup, each one shortly after a rejected connection ("Too many apps connected.") was closed.

Changes:

- `releaseCommonResources` drops the references without closing the handles. Every reader snapshots the field into a local first, so a handle still in use stays valid until that last reference goes away and `SafeWaitHandle`'s finalizer releases it. A lock was the alternative, but it can't cover both fields: `_pongReceived` is only touched under `_forPing`, while `_receivingExited` is used by the receive loop and by `closeHandshake`, neither of which holds that lock.
- Snapshot the field at the three readers that didn't: client `closeHandshake`, `processPongFrame` (which had a `catch (NullReferenceException)` papering over exactly this), and server `closeHandshake` (which read `_receivingExited` twice — null check, then wait).
- `Sweep()` clears `_sweeping` in a `finally`, so a throw can't leave the flag stuck at `true` and silently disable the sweep for the rest of the process's life.

Verified by building the netstandard2.0 DLL and running AltTester-Server's test suite against it: 133/133 passing. That exercises the normal connect/close paths, not the narrow ping-vs-teardown window itself.

Paired with alttester/AltTester-Server's own fix, which turns the sweep off (`KeepClean = false`) — a pong that doesn't arrive within `WaitTime` (1s) is treated as a dead session, which is what a backgrounded mobile app or a paused editor looks like. This PR is the hardening for every other consumer of the library.
